### PR TITLE
update apiVersion for apiregistration. Fixes Issue #1

### DIFF
--- a/metrics-server-components.yaml
+++ b/metrics-server-components.yaml
@@ -39,7 +39,7 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
Working through CKA lab: Discovering Pod Resource Usage with Kubernetes Metrics

When using current file:
```
cloud_user@k8s-control:~$ kubectl apply -f https://raw.githubusercontent.com/linuxacademy/content-cka-resources/master/metrics-server-components.yaml
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader created
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator created
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader created
serviceaccount/metrics-server created
deployment.apps/metrics-server created
service/metrics-server created
clusterrole.rbac.authorization.k8s.io/system:metrics-server created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server created
error: unable to recognize "https://raw.githubusercontent.com/linuxacademy/content-cka-resources/master/metrics-server-components.yaml": no matches for kind "APIService" in version "apiregistration.k8s.io/v1beta1"
```

After making the proposed change:
```
cloud_user@k8s-control:~$ kubectl apply -f metrics-server-components.yaml
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader unchanged
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator unchanged
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader unchanged
apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io created
serviceaccount/metrics-server unchanged
deployment.apps/metrics-server unchanged
service/metrics-server unchanged
clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server unchanged
cloud_user@k8s-control:~$ kubectl get --raw /apis/metrics.k8s.io/
{"kind":"APIGroup","apiVersion":"v1","name":"metrics.k8s.io","versions":[{"groupVersion":"metrics.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"metrics.k8s.io/v1beta1","version":"v1beta1"}}
cloud_user@k8s-control:~$ kubectl top pod -n beebox-mobile --sort-by cpu --selector app=auth
NAME           CPU(cores)   MEMORY(bytes)
auth-proc      101m         7Mi
beebox-auth2   0m           1Mi
beebox-auth1   0m           0Mi
```

According to [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/):

> [APIService](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#apiservice-v122)
> 
> The `apiregistration.k8s.io/v1beta1` API version of APIService is no longer served as of v1.22.
> 
> * Migrate manifests and API clients to use the `apiregistration.k8s.io/v1` API version, available since v1.10.
> * All existing persisted objects are accessible via the new API
> * No notable changes
